### PR TITLE
TH-289 Support TLS 1.3

### DIFF
--- a/php-library/templates/_base.ingress.tpl
+++ b/php-library/templates/_base.ingress.tpl
@@ -33,7 +33,7 @@ alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80}, {"HTTPS":443}]'
 alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
 alb.ingress.kubernetes.io/load-balancer-attributes: {{ include "phplibrary.base.ingress.annotations.loadBalancerAttributes" (list $top $ingress) }}
 alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds={{ $ingress.deregistrationDelay | default 15 }}
-alb.ingress.kubernetes.io/ssl-policy: {{ $ingress.sslPolicy | default "ELBSecurityPolicy-TLS-1-2-2017-01" }}
+alb.ingress.kubernetes.io/ssl-policy: {{ $ingress.sslPolicy | default "ELBSecurityPolicy-TLS13-1-2-Res-2021-06" }}
 {{- else }}
 alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80}]'
 {{- end }}


### PR DESCRIPTION
![image](https://github.com/Thiememeulenhoff/helm-libraries/assets/80959825/63c0c251-11b8-40be-9796-cc3671c5c624)

**Pro's**
- TLS 1.3 is on average 100ms faster on a full handshake compared to TLS 1.2
- Compliance with ISO 27001 and ISO 20648
- Internet Explorer not supported

**Con's**
- Internet Explorer not supported