### PR TITLE
update: nginx 1.28

### DIFF
--- a/php-library/templates/_impl.php-deployment.tpl
+++ b/php-library/templates/_impl.php-deployment.tpl
@@ -70,7 +70,7 @@ containers:
         {{- with .image | default (dict "" "") }}
         image:
             repository: {{ .repository | default "nginx" }}
-            tag: {{ .tag | default "1.26" }}
+            tag: {{ .tag | default "1.28" }}
         {{- end }}
         volumeMounts:
             {{- if $codeCopyEnabled }}


### PR DESCRIPTION
🔐 Security Enhancements
OCSP Support: NGINX 1.28 introduces OCSP validation for client certificates and OCSP stapling in the stream module, improving TLS handshake speed and security.
TLSv1 and TLSv1.1 Disabled by Default: These outdated and insecure protocols are now disabled by default.
SSL Context Inheritance: Reduces CPU load when using multiple server and location blocks.

🚀 Performance Improvements
CUBIC Congestion Control for QUIC: Boosts transfer speeds significantly, especially on high-latency connections (up to 73% faster at 100 ms latency).
Optimizations for gzip, gunzip, ssi, sub_filter, grpc_pass: Lower memory usage during long-lived requests. Improved CPU and memory efficiency for complex SSL configurations.

⚙️ New Features
Automatic Hostname Re-resolution in upstream groups without needing a restart. New proxy_pass_trailers Directive: Supports trailing headers from proxied servers.
Variable Support in *_limit_rate Directives: More flexible bandwidth control.
New keepalive_min_timeout Directive: Better control over keep-alive connections.

🔄 Compatibility
NGINX 1.28 is fully compatible with 1.26 configurations.